### PR TITLE
fix: when k closes the window it behaves itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ require("wrapping-paper").setup({
   remaps = {
     -- { "mode", "lhs", "rhs" }, -- these are added to the buffer on open, and removed on close
     { "n", "j", "v:count == 0 ? 'gj' : 'j'", { expr = true } },
-    { "n", "k", "v:count == 0 ? 'gk' : 'k'", { expr = true } },
+    { "n", "k", "v:count == 0 ? 'gk' : 'k'", { expr = true } }, -- This isn't really how it's done, the real mapping for k is more complicated, but it will function like this
     { "n", "0", "g0" },
     { "n", "_", "g0" },
     { "n", "^", "g^" },
     { "v", "j", "v:count == 0 ? 'gj' : 'j'", { expr = true } },
-    { "v", "k", "v:count == 0 ? 'gk' : 'k'", { expr = true } },
+    { "v", "k", "v:count == 0 ? 'gk' : 'k'", { expr = true } }, -- same as normal mode k ^
     { "v", "0", "g0" },
     { "v", "_", "g0" },
     { "v", "^", "g^" },


### PR DESCRIPTION
closes #3

Both normal and visual mappings for `k` are now using a custom function that compares the cursor location to the predicted column where the text first wraps (which we now track), and when it's less than this value we use `k` instead of `gk`.

Essentially, when the cursor is on the "first" line of the wrapping window, `k` is used instead of `gk`.

