### PR TITLE
Fix popup positioning

### DIFF
--- a/lua/wrapping-paper/init.lua
+++ b/lua/wrapping-paper/init.lua
@@ -139,7 +139,6 @@ M.wrap_line = function()
   local width = win_info.width - win_info.textoff
   width = math.min(width, config.width)
 
-  vim.api.nvim_win_set_cursor(0, { linenumber, 0 })
   local text = vim.api.nvim_get_current_line()
 
   local height = calc_height(text, width)
@@ -152,6 +151,7 @@ M.wrap_line = function()
   end
 
   open_buf = vim.api.nvim_get_current_buf()
+  vim.api.nvim_win_set_cursor(0, { linenumber, 0 })
 
   local popup = Popup({
     focusable = true,

--- a/lua/wrapping-paper/init.lua
+++ b/lua/wrapping-paper/init.lua
@@ -140,7 +140,6 @@ M.wrap_line = function()
 
   vim.api.nvim_win_set_cursor(0, { linenumber, 0 })
   local text = vim.api.nvim_get_current_line()
-  open_buf = vim.api.nvim_get_current_buf()
 
   local height = calc_height(text, width)
   if height <= 0 then
@@ -150,6 +149,9 @@ M.wrap_line = function()
   if height == 1 then
     return
   end
+
+  open_buf = vim.api.nvim_get_current_buf()
+
   local popup = Popup({
     focusable = true,
     enter = true,

--- a/lua/wrapping-paper/init.lua
+++ b/lua/wrapping-paper/init.lua
@@ -147,6 +147,9 @@ M.wrap_line = function()
     vim.notify("[wrapping-paper] Line is too short", vim.log.levels.INFO)
     return
   end
+  if height == 1 then
+    return
+  end
   local popup = Popup({
     focusable = true,
     enter = true,

--- a/lua/wrapping-paper/init.lua
+++ b/lua/wrapping-paper/init.lua
@@ -142,11 +142,7 @@ M.wrap_line = function()
   local text = vim.api.nvim_get_current_line()
 
   local height = calc_height(text, width)
-  if height <= 0 then
-    vim.notify("[wrapping-paper] Line is too short", vim.log.levels.INFO)
-    return
-  end
-  if height == 1 then
+  if height <= 1 then
     return
   end
 

--- a/lua/wrapping-paper/init.lua
+++ b/lua/wrapping-paper/init.lua
@@ -129,9 +129,10 @@ M.wrap_line = function()
 
   local cursor = vim.api.nvim_win_get_cursor(0)
   linenumber = cursor[1]
+  local cursor_col = cursor[2]
 
   local win = vim.api.nvim_get_current_win()
-  local pos = vim.fn.screenpos(win, linenumber, 0)
+  local pos = vim.fn.screenpos(win, linenumber, cursor_col)
   local win_info = vim.fn.getwininfo(win)[1]
   local row = pos.row - 1
   local col = win_info.wincol + win_info.textoff - 1


### PR DESCRIPTION
Previously, if the cursor was near the end of the line when calling `wrap_line`, the popup would be positioned incorrectly near the top of the window.

Also fixes a bug where if `if height <= 0 then` one time, the plugin would stop functioning when the user tried wrapping future lines due to `open_buf` not being `nil`.

Finally, added a check to see if the wrapped height would be 1, returning early if so. This way the popup isn't created unnecessarily for short lines.